### PR TITLE
Fix package.json paths to typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "lib/react-table-container.js",
   "module": "es/react-table-container.js",
   "jsnext:main": "es/react-table-container.js",
-  "typings": "./index.d.ts",
+  "typings": "index.d.ts",
   "files": [
     "lib",
     "es",
     "dist",
     "src",
-    "./index.d.ts"
+    "index.d.ts"
   ],
   "scripts": {
     "clean": "rimraf lib es dist",


### PR DESCRIPTION
This fixes the path in to typings in package.json so they are recognized by npm and copied when user does an install.