### PR TITLE
Remove preventDefault onMouseMove

### DIFF
--- a/src/TableHorizontalScrollbar.tsx
+++ b/src/TableHorizontalScrollbar.tsx
@@ -173,8 +173,6 @@ export class TableHorizontalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseMove = (event: MouseEvent): void => {
-    event.preventDefault();
-
     /* tslint:disable:prefer-const */
     let {
       percentageScrolled,

--- a/src/TableVerticalScrollbar.tsx
+++ b/src/TableVerticalScrollbar.tsx
@@ -187,8 +187,6 @@ export class TableVerticalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseMove = (event: MouseEvent): void => {
-    event.preventDefault();
-
     /* tslint:disable:prefer-const */
     let {
       percentageScrolled,


### PR DESCRIPTION
Resolves #3 : The component has event listeners for mousemove events, and in the event handlers it calls `event.preventDefault`, which prevents users from selecting/highlighting any text on the page.

This PR addresses the bug by removing the `preventDefaults` in the offending handlers. There is no other regression in behaviour as a result of it that I can note.

Hope this helps!