### PR TITLE
Heatherbooker fix/debug prevent default

### DIFF
--- a/src/TableHorizontalScrollbar.tsx
+++ b/src/TableHorizontalScrollbar.tsx
@@ -187,6 +187,8 @@ export class TableHorizontalScrollbar extends React.Component<IProps, IState> {
       return;
     }
 
+    event.preventDefault();
+
     const currentMoveClientX = event.clientX;
     const deltaX = currentMoveClientX - previousMoveClientX;
 
@@ -210,13 +212,13 @@ export class TableHorizontalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseUp = (event: MouseEvent): void => {
-    event.preventDefault();
-
     const { isMoving } = this.state;
 
     if (!isMoving) {
       return;
     }
+
+    event.preventDefault();
 
     this.setState({
       isMoving: false,

--- a/src/TableHorizontalScrollbar.tsx
+++ b/src/TableHorizontalScrollbar.tsx
@@ -173,8 +173,6 @@ export class TableHorizontalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseMove = (event: MouseEvent): void => {
-    event.preventDefault();
-
     /* tslint:disable:prefer-const */
     let {
       percentageScrolled,

--- a/src/TableVerticalScrollbar.tsx
+++ b/src/TableVerticalScrollbar.tsx
@@ -202,6 +202,8 @@ export class TableVerticalScrollbar extends React.Component<IProps, IState> {
       return;
     }
 
+    event.preventDefault();
+
     const currentMoveClientY = event.clientY;
     const deltaY = currentMoveClientY - previousMoveClientY;
 
@@ -226,9 +228,13 @@ export class TableVerticalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseUp = (event: MouseEvent): void => {
-    event.preventDefault();
-
     const { isMoving } = this.state;
+
+    if (!isMoving) {
+      return;
+    }
+
+    event.preventDefault();
 
     this.setState({
       isMoving: false,

--- a/src/TableVerticalScrollbar.tsx
+++ b/src/TableVerticalScrollbar.tsx
@@ -187,8 +187,6 @@ export class TableVerticalScrollbar extends React.Component<IProps, IState> {
   };
 
   private onMouseMove = (event: MouseEvent): void => {
-    event.preventDefault();
-
     /* tslint:disable:prefer-const */
     let {
       percentageScrolled,


### PR DESCRIPTION
Hi @heatherbooker, many thanks for another pull request of yours! I created this one based off yours, because I couldn't add new changes to it.

You were right, the event.preventDefault() calls were stopping the user from selecting any text in the page. Instead of deleting those calls, I'm now only calling them if the user is interacting with the scrollbars which should fix this issue. To be honest, we currently don't need to prevent the default behaviour in this case, but we might in the future if we add more custom functionality. So I'd rather leave them there.

Have a look at this pull request, and if you are happy with it, I'll merge it.

Thanks again for your help!